### PR TITLE
fix: download cosign v3.0.6 static binary to support verification of newer images signed with the new bundle format.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM alpine:3.23
 
-RUN apk add --no-cache cosign crane bash curl libuuid libblkid
+RUN apk add --no-cache crane bash curl libuuid libblkid
+
+COPY --from=ghcr.io/sigstore/cosign/cosign:v3.0.6@sha256:de9c65609e6bde17e6b48de485ee788407c9502fa08b8f4459f595b21f56cd00 /ko-app/cosign /usr/local/bin/
+RUN cosign version
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
Hey, sorry for not catching this earlier, but alpine 3.23 still has cosign v2.4.3 in the community repository for v3.23 branch, which doesnt support verifying images signed with the new bundle format. I think it was added in cosign version 3.x, so im opening this pr , which removes cosign from the  apk install command and instead added docker copy command to get the latest release version from their published image.